### PR TITLE
ci: netlify redirect conf based on branch

### DIFF
--- a/netlify-redirect-main.toml
+++ b/netlify-redirect-main.toml
@@ -1,0 +1,19 @@
+# redirects in main env
+
+[[redirects]]
+  from = "/l1/*"
+  to = "https://prealpha-rpc.scroll.io/l1/:splat"
+  status = 200
+[[redirects]]
+  from = "/l2/*"
+  to = "https://prealpha-rpc.scroll.io/l2/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/faucetapi/*"
+  to = "https://prealpha-api.scroll.io/faucet/:splat"
+  status = 200
+[[redirects]]
+  from = "/bridgeapi/*"
+  to = "https://prealpha-api.scroll.io/bridgehistory/api/:splat"
+  status = 200

--- a/netlify-redirect-not-main.toml
+++ b/netlify-redirect-not-main.toml
@@ -1,0 +1,29 @@
+# redirects in staging env
+
+# these two redirects are for MAIN only, as a transitional help
+# TODO: change rpc redirect to staging
+# [[redirects]]
+#   from = "/l1/*"
+#   to = "https://staging-prealpha-rpc.scroll.io/l1/:splat"
+#   status = 200
+# [[redirects]]
+#   from = "/l2/*"
+#   to = "https://staging-prealpha-rpc.scroll.io/l2/:splat"
+#   status = 200
+[[redirects]]
+  from = "/l1/*"
+  to = "https://prealpha-rpc.scroll.io/l1/:splat"
+  status = 200
+[[redirects]]
+  from = "/l2/*"
+  to = "https://prealpha-rpc.scroll.io/l2/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/faucetapi/*"
+  to = "https://staging-prealpha-api.scroll.io/faucet/:splat"
+  status = 200
+[[redirects]]
+  from = "/bridgeapi/*"
+  to = "https://staging-prealpha-api.scroll.io/bridgehistory/api/:splat"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,33 +1,13 @@
+[build]
+  publish = "build/"
 
-# these two redirects are for MAIN only, as a transitional help
-[[redirects]]
-  from = "/l1/*"
-  to = "https://prealpha-rpc.scroll.io/l1/:splat"
-  status = 200
-[[redirects]]
-  from = "/l2/*"
-  to = "https://prealpha-rpc.scroll.io/l2/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/faucetapi/*"
-  to = "https://staging-prealpha-api.scroll.io/faucet/:splat"
-  status = 200
-[[redirects]]
-  from = "/bridgeapi/*"
-  to = "https://staging-prealpha-api.scroll.io/bridgehistory/api/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/early-dev"
-  to = "https://scrollzkp.typeform.com/early-dev"
-
-[[redirects]]
-  from = "/*"
-  to = "/"
-  status = 200
+  # build command (override the one in Netlify UI)
+  command = "yarn ci"
 
 [build.environment]
+  # Debug netlify build env
+  # NETLIFY_BUILD_DEBUG=true
+
   # Settings in the [build] context are global and are applied to
   # all contexts unless otherwise overridden by more specific contexts.
   REACT_APP_ETH_SYMBOL="TSETH"
@@ -111,3 +91,16 @@
   REACT_APP_ROUTER_ADDRESS="0xaDa15C4AD1a323c3e58b8198Ea41fCE261937001"
   REACT_APP_MULTICALL_ADDR="0x6e5754A5EE25c1D385cf1e305e27162C54cBA1a5"
   REACT_APP_L2_WETH_ADDRESS="0x6b29C65597Fa2aC80Ab181989969092971f1Fa4e"
+
+# redirects here affects ALL env
+# to add redirects to specific env, check
+# - netlify-redirect-main.toml
+# - netlify-redirect-not-main.toml
+[[redirects]]
+  from = "/early-dev"
+  to = "https://scrollzkp.typeform.com/early-dev"
+
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -56,16 +56,14 @@
   },
   "scripts": {
     "start": "BROWSER=none craco start",
-    "build": "CI=false && craco build",
+    "build": "CI=false craco build",
+    "ci": "node scripts/ci.js && yarn build",
     "test": "craco test",
     "lint": "eslint --fix \"**/*.{ts,tsx}\"",
     "eject": "craco eject"
   },
   "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ],
+    "extends": ["react-app", "react-app/jest"],
     "rules": {
       "quotes": [
         2,
@@ -74,17 +72,11 @@
           "avoidEscape": true
         }
       ],
-      "react/self-closing-comp": [
-        1
-      ]
+      "react/self-closing-comp": [1]
     }
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
@@ -137,6 +129,7 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "ethers": "^5.0.7",
+    "fs-extra": "^11.1.0",
     "https-browserify": "^1.0.0",
     "i18next": "^15.0.9",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/scripts/ci-utils.js
+++ b/scripts/ci-utils.js
@@ -1,0 +1,75 @@
+const fs = require("fs/promises");
+const fse = require("fs-extra");
+
+function isInCI() {
+  return process.env.CI === "true";
+}
+
+// netlify env for PR ci/redirect-based-on-branch -> staging
+// BRANCH pull/37/head
+// HEAD ci/redirect-based-on-branch
+function isBranch(branchName) {
+  return process.env.BRANCH === branchName;
+}
+
+// fileA string + / + fileB string write to fileC
+async function concatFileABAndWriteToC(fileA, fileB, fileC) {
+  const [a, b] = await Promise.all(
+    [fileA, fileB].map((path) => fs.readFile(path, { encoding: "utf-8" }))
+  ).catch((err) => {
+    console.error(`Failed to read file ${fileA} or ${fileB}`);
+    throw err;
+  });
+
+  await fse.outputFile(fileC, a + "\n" + b).catch((err) => {
+    console.error(`Failed to write file to ${fileC}`);
+    throw err;
+  });
+}
+
+// prettier-ignore
+function debugCIEnv() {
+  console.debug("------DEBUG CI ENV------BEGIN");
+  console.debug("CI", process.env.CI);
+  console.debug("NETLIFY", process.env.NETLIFY);
+  console.debug("BUILD_ID", process.env.BUILD_ID);
+  console.debug("CONTEXT", process.env.CONTEXT);
+  console.debug("NODE_VERSION", process.env.NODE_VERSION);
+  console.debug("NODE_ENV", process.env.NODE_ENV);
+  console.debug("NPM_VERSION", process.env.NPM_VERSION);
+  console.debug("NPM_FLAGS", process.env.NPM_FLAGS);
+  console.debug("NPM_TOKEN", process.env.NPM_TOKEN);
+  console.debug("NETLIFY_USE_YARN", process.env.NETLIFY_USE_YARN);
+  console.debug("YARN_VERSION", process.env.YARN_VERSION);
+  console.debug("YARN_FLAGS", process.env.YARN_FLAGS);
+  console.debug("RUBY_VERSION", process.env.RUBY_VERSION);
+  console.debug("PHP_VERSION", process.env.PHP_VERSION);
+  console.debug("PNPM_FLAGS", process.env.PNPM_FLAGS);
+  console.debug("PYTHON_VERSION", process.env.PYTHON_VERSION);
+  console.debug("HUGO_VERSION", process.env.HUGO_VERSION);
+  console.debug("SWIFT_VERSION", process.env.SWIFT_VERSION);
+  console.debug("GO_VERSION", process.env.GO_VERSION);
+  console.debug("NETLIFY_NEXT_PLUGIN_SKIP", process.env.NETLIFY_NEXT_PLUGIN_SKIP);
+  console.debug("DISABLE_IPX", process.env.DISABLE_IPX);
+  console.debug("NETLIFY_SKIP_GATSBY_FUNCTIONS", process.env.NETLIFY_SKIP_GATSBY_FUNCTIONS);
+  console.debug("GATSBY_CLOUD_IMAGE_CDN", process.env.GATSBY_CLOUD_IMAGE_CDN);
+  console.debug("GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE", process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE);
+  console.debug("AWS_LAMBDA_JS_RUNTIME", process.env.AWS_LAMBDA_JS_RUNTIME);
+  console.debug("REPOSITORY_URL", process.env.REPOSITORY_URL);
+  console.debug("BRANCH", process.env.BRANCH);
+  console.debug("HEAD", process.env.HEAD);
+  console.debug("COMMIT_REF", process.env.COMMIT_REF);
+  console.debug("CACHED_COMMIT_REF", process.env.CACHED_COMMIT_REF);
+  console.debug("PULL_REQUEST", process.env.PULL_REQUEST);
+  console.debug("REVIEW_ID", process.env.REVIEW_ID);
+  console.debug("URL", process.env.URL);
+  console.debug("DEPLOY_URL", process.env.DEPLOY_URL);
+  console.debug("DEPLOY_PRIME_URL", process.env.DEPLOY_PRIME_URL);
+  console.debug("DEPLOY_ID", process.env.DEPLOY_ID);
+  console.debug("SITE_NAME", process.env.SITE_NAME);
+  console.debug("SITE_ID", process.env.SITE_ID);
+  console.debug("NETLIFY_IMAGES_CDN_DOMAIN", process.env.NETLIFY_IMAGES_CDN_DOMAIN);
+  console.debug("------DEBUG CI ENV------END");
+}
+
+module.exports = { isInCI, isBranch, concatFileABAndWriteToC, debugCIEnv };

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -1,0 +1,62 @@
+// file to run pre-build tasks in netlify ci
+const ciUtils = require("./ci-utils.js");
+const path = require("path");
+
+ciUtils.debugCIEnv();
+
+const projectRoot = path.resolve(__dirname, "..");
+
+async function mainBranch() {
+  // prepend content of netlify-redirect-main.toml into netlify.toml
+  await ciUtils
+    .concatFileABAndWriteToC(
+      path.resolve(projectRoot, "netlify-redirect-main.toml"),
+      path.resolve(projectRoot, "netlify.toml"),
+      path.resolve(projectRoot, "netlify.toml")
+    )
+    .catch((err) => {
+      console.error(
+        "Failed to concat netlify.toml and netlify-redirect-main.toml",
+        err
+      );
+      throw err;
+    });
+}
+
+async function otherBranch() {
+  // prepend content of netlify-redirect-not-main.toml into netlify.toml
+  await ciUtils
+    .concatFileABAndWriteToC(
+      path.resolve(projectRoot, "netlify-redirect-not-main.toml"),
+      path.resolve(projectRoot, "netlify.toml"),
+      path.resolve(projectRoot, "netlify.toml")
+    )
+    .catch((err) => {
+      console.error(
+        "Failed to concat netlify.toml and netlify-redirect-not-main.toml",
+        err
+      );
+      throw err;
+    });
+}
+
+async function run() {
+  // check if in CI
+  if (!ciUtils.isInCI()) return;
+
+  // after code MERGED into main
+  if (ciUtils.isBranch("main")) {
+    await mainBranch();
+    return;
+  }
+
+  // when on any other branch
+  // e.g.
+  // commit on any branch other than main
+  // pull request FROM ANY BRANCH TO ANY BRANCH
+  await otherBranch();
+}
+
+(async function () {
+  await run();
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8782,6 +8782,15 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
+  integrity sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"


### PR DESCRIPTION
# Summary
add `ci` script in package.json, to run in Netlify CI

The `ci` script is a NodeJS script at `scripts/ci.js`, it dynamically generate a new `netlify.toml` based on `BRANCH` env provided by Netlify, `netlify-redirect-main.toml` and `netlify-redirect-not-main.toml`

Netlify CI env https://docs.netlify.com/configure-builds/environment-variables/#git-metadata

Todo after this merged:
  * [ ] redirect staging rpc in netlify-redirect-not-main.toml once this commit merged into main branch
  * [ ] remove the build config in Netlify UI once this commit merged into main

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203532864257627