### PR TITLE
fix: title for not found&&space in network name

### DIFF
--- a/src/hooks/useMatchedRoute.tsx
+++ b/src/hooks/useMatchedRoute.tsx
@@ -10,6 +10,6 @@ export default function useMatchedRoute() {
     if (matchPath((route as any).fullPath || route.path, pathname)) {
       return route
     }
-    return PrealphaRoutes[PrealphaRoutes.length - 1]
   }
+  return PrealphaRoutes[PrealphaRoutes.length - 1]
 }

--- a/src/pages/faucet/index.tsx
+++ b/src/pages/faucet/index.tsx
@@ -280,7 +280,7 @@ export default function Home() {
                 <p className="mb-[6px] md:mr-[6px]">Scroll L1 and L2 not added yet?</p>
                 <Link to="add-network">
                   <span className="text-[#00A6F2] cursor-pointer font-semibold">
-                    Add Scroll L1{TESTNET_NAME} and L2{TESTNET_NAME}
+                    Add Scroll L1 {TESTNET_NAME} and L2 {TESTNET_NAME}
                   </span>
                 </Link>
               </div>


### PR DESCRIPTION
1. title for not found
2. space in network name[faucet]