### PR TITLE
ci: test version bump

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,15 @@
+name: Auto Approve
+on:
+  pull_request_target:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,26 @@
+name: Auto Merge
+on:
+  pull_request:
+    branches:
+      - "main"
+    types:
+      - labeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@22948e0bc22f0aa673800da838595a3e7347e584"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -10,6 +10,7 @@ jobs:
     name: "Bump Version on main"
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:
@@ -24,5 +25,18 @@ jobs:
         uses: "phips28/gh-action-bump-version@25cd8ffb8ec95f16f83a8dac9557a845e4fa9e21"
         with:
           tag-prefix: "v"
+          skip-push: "true"
         env:
-          GITHUB_TOKEN: ${{ secrets.WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Version Bump Commit Message
+        run: echo "::set-output name=title::$(git log --pretty=format:"%s" -1)"
+        id: get-version-bump-commit-message
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
+        with:
+          token: ${{ secrets.WRITE_TOKEN }}
+          delete-branch: false
+          branch: ci/_bump-version
+          title: ${{ steps.get-version-bump-commit-message.outputs.title }}
+          labels: "bot/bump-version, automerge"
+          body: ""


### PR DESCRIPTION
process
1. commit pushed into `main`
2. `secrets.WRITE_TOKEN` create a new [version-bump commit](https://github.com/scroll-tech/frontends/pull/110/commits/3b6073f04cee395097d4c52297790f176c5545b4), push it to `ci/_bump-version` branch, and create a [PR](https://github.com/scroll-tech/frontends/pull/110) from `ci/_bump-version` branch to `main`
3. `secrets.GITHUB_TOKEN` (default github action bot) approve and merge the PR

version bump logic not changed

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203856202129185