### PR TITLE
Fix wallet_switchEthereumChain chainId bug

### DIFF
--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -4,7 +4,7 @@ export const switchNetwork = async (chainId: number) => {
   try {
     await window.ethereum.request({
       method: "wallet_switchEthereumChain",
-      params: [{ chainId: "0x" + chainId.toString() }],
+      params: [{ chainId: "0x" + chainId.toString(16) }],
     })
     return true
   } catch (error) {


### PR DESCRIPTION
reference https://eips.ethereum.org/EIPS/eip-695
chain_id should pass as a hexadecimal string.