### PR TITLE
fix: spacing fixes for ecosystem page

### DIFF
--- a/src/pages/ecosystem/Gallery/GalleryItem.tsx
+++ b/src/pages/ecosystem/Gallery/GalleryItem.tsx
@@ -100,7 +100,7 @@ const GalleryItem = props => {
           whileHover={{ boxShadow: "2px 2px 10px 2px rgba(131, 131, 131, 0.5)" }}
           transition={{ duration: 0.3, ease: "easeInOut" }}
         >
-          <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <Box sx={{ display: "flex", justifyContent: "flex-end", position: "absolute", width: "100%", marginLeft: "-1rem", paddingX: "1rem" }}>
             <InfoOutlined sx={{ color: "#686868" }}></InfoOutlined>
           </Box>
           <Stack direction="column" spacing={2} alignItems="center" sx={{ mt: "7rem" }}>
@@ -128,7 +128,7 @@ const GalleryItem = props => {
               <ReplayOutlined sx={{ color: "#686868" }}></ReplayOutlined>
             </Stack>
             <Typography
-              sx={{ mt: "2rem", px: "1rem", lineHeight: ["1.8rem", "1.6rem"], fontFamily: "Inter", fontWeight: 500, fontSize: ["1.6rem", "1.4rem"] }}
+              sx={{ mb: "1rem", px: "1rem", lineHeight: ["1.8rem", "1.6rem"], fontFamily: "Inter", fontWeight: 500, fontSize: ["1.6rem", "1.4rem"] }}
             >
               {desc}
             </Typography>

--- a/src/pages/ecosystem/Gallery/GalleryItem.tsx
+++ b/src/pages/ecosystem/Gallery/GalleryItem.tsx
@@ -52,6 +52,19 @@ const FaceSide = styled(motion.div)(
 `,
 )
 
+const IconBox = styled(Box)(
+  ({ theme }) => `
+  position: absolute;
+  width: 100%;
+  margin-left: -1rem;
+  padding: 0 1rem;
+  ${theme.breakpoints.down("sm")} {
+    padding: 0 1.6rem;
+    margin-left: -1.6rem;
+  };
+  `,
+)
+
 const Tag = styled("span")(
   ({ theme }) => `
   display: inline-block;
@@ -100,9 +113,9 @@ const GalleryItem = props => {
           whileHover={{ boxShadow: "2px 2px 10px 2px rgba(131, 131, 131, 0.5)" }}
           transition={{ duration: 0.3, ease: "easeInOut" }}
         >
-          <Box sx={{ display: "flex", justifyContent: "flex-end", position: "absolute", width: "100%", marginLeft: "-1rem", paddingX: "1rem" }}>
+          <IconBox sx={{ display: "flex", justifyContent: "flex-end" }}>
             <InfoOutlined sx={{ color: "#686868" }}></InfoOutlined>
-          </Box>
+          </IconBox>
           <Stack direction="column" spacing={2} alignItems="center" sx={{ mt: "7rem" }}>
             <Stack direction="row" spacing={1.25} alignItems="center">
               <Avatar alt={name} src={logo} variant="rounded" sx={{ width: 84, height: 84 }}></Avatar>


### PR DESCRIPTION
Fixes vertical centering on the ecosystem page. Frontside and backside of the card use different techniques since one uses a box and the other a vertical stack.

Frontside makes the row with the icon positioned absolute, so the vertical centering of the logos is in relation to the card, not the icon.

Backside removes a top margin on the `p`, and adds a small bottom margin to allow the text block to be positioned in a way where there is a slight weight to the overall bottom margin (and white-space).

Before:
<img width="1345" alt="Screenshot 2023-04-30 at 1 54 54 PM" src="https://user-images.githubusercontent.com/4205837/235371614-8c0f5126-9d1c-47b1-9a08-c004438a97e3.png">

After:
<img width="1345" alt="Screenshot 2023-04-30 at 1 55 00 PM" src="https://user-images.githubusercontent.com/4205837/235371617-a1b2f6a5-dec8-43b5-b884-3134fe3d1237.png">