### PR TITLE
feat: optimize ecosystem image perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash": "^4.17.21",
     "numbro": "^2.3.6",
     "react": "^18.2.0",
+    "react-cool-img": "^1.2.12",
     "react-countdown": "^2.3.2",
     "react-dom": "^18.2.0",
     "react-ga4": "^1.4.1",
@@ -103,9 +104,9 @@
     ]
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.10.6",
     "@ethersproject/experimental": "^5.0.1",
     "@popperjs/core": "^2.4.4",
-    "@emotion/babel-plugin": "^11.10.6",
     "@reach/dialog": "^0.10.3",
     "@reach/portal": "^0.10.3",
     "@reduxjs/toolkit": "^1.3.5",

--- a/src/apis/ecosystem.ts
+++ b/src/apis/ecosystem.ts
@@ -1,1 +1,3 @@
-export const fetchEcosystemListUrl = "https://scroll-tech.github.io/ecosystem-list/ecosystem.json"
+export const ecosystemOrigin = "https://scroll-eco-list.netlify.app"
+export const ecosystemListHashUrl = ecosystemOrigin + "/docs/ecosystem.hash.json"
+export const ecosystemListLogoUrl = ecosystemOrigin + "/logos/"

--- a/src/pages/ecosystem/Gallery/GalleryItem.tsx
+++ b/src/pages/ecosystem/Gallery/GalleryItem.tsx
@@ -1,8 +1,9 @@
 import { motion } from "framer-motion"
 import { useState } from "react"
+import Img from "react-cool-img"
 
 import { InfoOutlined, ReplayOutlined } from "@mui/icons-material"
-import { Avatar, Box, Stack, SvgIcon, Typography } from "@mui/material"
+import { Box, Stack, SvgIcon, Typography } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
 import { socialLinks } from "../helper"
@@ -87,8 +88,11 @@ const variants = {
 
 const GalleryItem = props => {
   const {
-    item: { name, logo, tags, desc, website, twitterHandle },
+    logoBaseUrl,
+    item: { name, hash, ext, tags, desc, website, twitterHandle },
   } = props
+
+  const logo = logoBaseUrl + name + ext
 
   const [isBack, setIsBack] = useState(false)
 
@@ -118,7 +122,7 @@ const GalleryItem = props => {
           </IconBox>
           <Stack direction="column" spacing={2} alignItems="center" sx={{ mt: "7rem" }}>
             <Stack direction="row" spacing={1.25} alignItems="center">
-              <Avatar alt={name} src={logo} variant="rounded" sx={{ width: 84, height: 84 }}></Avatar>
+              <Img alt={name} src={logo} placeholder={hash} width={84} height={84}></Img>
               <Typography sx={{ fontFamily: "Inter", fontWeight: 600, fontSize: ["2rem", "2.4rem"], width: "min-content" }}>{name}</Typography>
             </Stack>
             <Stack direction="row" sx={{ flexWrap: "wrap", justifyContent: "center" }}>
@@ -135,7 +139,7 @@ const GalleryItem = props => {
           <Stack direction="column" justifyContent="space-between" sx={{ height: "100%" }}>
             <Stack direction="row" justifyContent="space-between">
               <Stack direction="row" alignItems="center" spacing={0.5}>
-                <Avatar alt={name} src={logo} variant="rounded" sx={{ width: 22, height: 22 }}></Avatar>
+                <Img alt={name} src={logo} placeholder={hash} width={22} height={22}></Img>
                 <Typography sx={{ fontWeight: 600, fontSize: 12 }}>{name}</Typography>
               </Stack>
               <ReplayOutlined sx={{ color: "#686868" }}></ReplayOutlined>

--- a/src/pages/ecosystem/Gallery/index.tsx
+++ b/src/pages/ecosystem/Gallery/index.tsx
@@ -4,7 +4,7 @@ import useSWR from "swr"
 import { Alert, Snackbar } from "@mui/material"
 import { styled } from "@mui/material/styles"
 
-import { fetchEcosystemListUrl } from "@/apis/ecosystem"
+import { ecosystemListHashUrl, ecosystemListLogoUrl } from "@/apis/ecosystem"
 import LoadingPage from "@/components/LoadingPage"
 
 import GalleryItem from "./GalleryItem"
@@ -31,7 +31,7 @@ const Container = styled("div")(
 
 const Gallery = () => {
   const [errorMsg, setErrorMsg] = useState("")
-  const { data: ecosystemList, isLoading } = useSWR(fetchEcosystemListUrl, url => {
+  const { data: ecosystemList, isLoading } = useSWR(ecosystemListHashUrl, url => {
     return scrollRequest(url).catch(() => {
       setErrorMsg("Fail to fetch ecosystem list")
       return null
@@ -48,7 +48,7 @@ const Gallery = () => {
       ) : (
         <Container>
           {ecosystemList?.map(item => (
-            <GalleryItem key={item.name} item={item}></GalleryItem>
+            <GalleryItem key={item.name} logoBaseUrl={ecosystemListLogoUrl} item={item}></GalleryItem>
           ))}
           <Snackbar open={!!errorMsg} autoHideDuration={6000} onClose={handleClose}>
             <Alert severity="error" onClose={handleClose}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13501,6 +13501,11 @@ react-clientside-effect@^1.2.6:
   dependencies:
     "@babel/runtime" "^7.12.13"
 
+react-cool-img@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/react-cool-img/-/react-cool-img-1.2.12.tgz#b7a65053d5e234417afeb0791ce650783ebf80db"
+  integrity sha512-HambbjVszVVCNAEps+wReo9znzhgpq/72DCRvz4ahKkubEUV/ij0WH3RCQ37rcAPezhchpH75VutDE/ENgWegA==
+
 react-countdown@^2.3.2:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/react-countdown/-/react-countdown-2.3.5.tgz#70c035b5cbc7e8fdb4ad91fe5f44afd7a7933a68"


### PR DESCRIPTION
use react-tool-img https://github.com/wellyshen/react-cool-img for
placeholder support and lazy loading

use logos in ecosystem-list https://github.com/scroll-tech/ecosystem-list served by netlify

placeholder image generated using thumbhash https://evanw.github.io/thumbhash/


https://user-images.githubusercontent.com/15090582/236754565-52e6de64-bb55-474a-956d-01257f346925.mp4

