### PR TITLE
fix: gas fee + relay fee

### DIFF
--- a/src/pages/bridge/Send/index.tsx
+++ b/src/pages/bridge/Send/index.tsx
@@ -86,7 +86,7 @@ const Send: FC = () => {
       const { maxFeePerGas: gasPrice } = await networksAndSigners[fromNetwork.chainId].provider.getFeeData()
       try {
         const gasLimit = await estimateSend()
-        const estimatedGasCost = (BigInt(gasLimit) * BigInt(gasPrice || 1e9) * BigInt(140)) / BigInt(100)
+        const estimatedGasCost = BigInt(gasLimit) * BigInt(gasPrice || 1e9)
         setEstimatedGasCost(estimatedGasCost)
       } catch (error) {
         setEstimatedGasCost(undefined)
@@ -102,13 +102,15 @@ const Send: FC = () => {
   const { getPriceFee } = usePriceFee()
 
   useEffect(() => {
-    handleTotalBonderFeeDisplay()
-  }, [chainId, fromTokenAmount, fromToken])
+    if (estimatedGasCost !== undefined) {
+      handleTotalBonderFeeDisplay()
+    }
+  }, [chainId, fromTokenAmount, fromToken, estimatedGasCost])
 
   const handleTotalBonderFeeDisplay = async () => {
     if (networksAndSigners[fromNetwork.chainId]?.signer) {
       const fee = await getPriceFee(fromToken, fromNetwork.isL1)
-      const display = fromTokenAmount ? toTokenDisplay(fee) + " " + ETH_SYMBOL : "-"
+      const display = fromTokenAmount ? toTokenDisplay(fee + (estimatedGasCost as bigint)) + " " + ETH_SYMBOL : "-"
       setTotalBonderFeeDisplay(display)
     }
   }


### PR DESCRIPTION
1. the fee displayed on the page should be the `gas fee + relay fee` and should be consistent with the fee to be considered when calculating sufficient balance.
2. tell the user the maximum value of the amount directly instead of telling them how much to subtract from the current value.
<img width="614" alt="image" src="https://github.com/scroll-tech/frontends/assets/21138718/50feb7f5-f6f4-46aa-bf9a-74e9e16436bd">

issue: https://github.com/scroll-tech/.github/issues/1