### PR TITLE
Do not auto requesting switch network when user rejected

### DIFF
--- a/src/constants/storageKey.ts
+++ b/src/constants/storageKey.ts
@@ -13,4 +13,6 @@ export const APP_VERSION = "appVersion"
 
 export const BLOCK_NUMBERS = "blockNumbers"
 
+export const AUTO_REQUESTING_SWITCH_NETWORK = "autoRequestingSwitchNetwork"
+
 export const STORAGE_AVAILABLE = "__storage_test__"

--- a/src/hooks/useIsSmartContractWallet.ts
+++ b/src/hooks/useIsSmartContractWallet.ts
@@ -10,8 +10,10 @@ export default function useIsSmartContractWallet() {
     const checkAddress = async () => {
       if (!provider || !walletCurrentAddress) return
 
-      const code = await provider.getCode(walletCurrentAddress)
-      setIsSmartContractWallet(code !== "0x")
+      try {
+        const code = await provider.getCode(walletCurrentAddress)
+        setIsSmartContractWallet(code !== "0x")
+      } catch (error) {}
     }
 
     checkAddress()

--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -7,6 +7,10 @@ export const switchNetwork = async (chainId: number) => {
       id: chainId,
     })
   } catch (error) {
+    // 4001 means user rejected the request
+    if (error.code === 4001) {
+      throw error
+    }
     // 4902 or -32603 mean chain doesn't exist
     if (~error.message.indexOf("wallet_addEthereumChain") || error.code === 4902 || error.code === -32603) {
       const { chains } = getNetwork()


### PR DESCRIPTION
Do not auto requesting switch network when user rejected, current bevahiour is very aggressive and leads to issues with infinite wallet interaction requests.