### PR TITLE
Change Unifra in Header Nav to L2Scan

### DIFF
--- a/src/components/Header/constants.ts
+++ b/src/components/Header/constants.ts
@@ -47,7 +47,7 @@ const navigations = [
             isExternal: true,
           },
           {
-            label: "Unifra Explorer",
+            label: "L2Scan Explorer",
             key: "unifraBlockExplorer",
             href: EXPLORER_URL.Unifra,
             isExternal: true,


### PR DESCRIPTION
Changed "Unifra Block Explorer" text in heading to "L2Scan Block Explorer"