### PR TITLE
fix: bind txType and fromNetwork

### DIFF
--- a/src/pages/new-bridge/Send/index.tsx
+++ b/src/pages/new-bridge/Send/index.tsx
@@ -59,8 +59,7 @@ const useStyles = makeStyles()(theme => ({
 const Send = () => {
   const { classes } = useStyles()
   const { chainId } = useRainbowContext()
-  const { txType, fromNetwork, toNetwork, withDrawStep, changeTxType, changeTxResult, changeFromNetwork, changeToNetwork, changeIsNetworkCorrect } =
-    useBridgeStore()
+  const { txType, fromNetwork, withDrawStep, changeTxType, changeTxResult, changeIsNetworkCorrect } = useBridgeStore()
 
   useEffect(() => {
     let networkCorrect
@@ -76,8 +75,6 @@ const Send = () => {
 
   const handleChange = (e, newValue) => {
     changeTxType(newValue)
-    changeFromNetwork(toNetwork)
-    changeToNetwork(fromNetwork)
     changeTxResult(null)
   }
 

--- a/src/pages/new-bridge/index.tsx
+++ b/src/pages/new-bridge/index.tsx
@@ -1,10 +1,12 @@
 // import createCache from "@emotion/cache"
+import { useEffect } from "react"
 import { isMobileOnly } from "react-device-detect"
 
 import { Stack, Typography } from "@mui/material"
 
 import GlobalWarning from "@/components/GlobalWarning"
 import SectionWrapper from "@/components/SectionWrapper"
+import { NETWORKS } from "@/constants"
 import AppProvider from "@/contexts/AppContextProvider"
 import { PriceFeeProvider } from "@/contexts/PriceFeeProvider"
 import useBridgeStore from "@/stores/bridgeStore"
@@ -16,7 +18,18 @@ import Send from "./Send"
 import TxHistory from "./TxHistory"
 
 const Bridge = () => {
-  const { mode } = useBridgeStore()
+  const { mode, txType, changeFromNetwork, changeToNetwork } = useBridgeStore()
+
+  useEffect(() => {
+    if (txType === "Deposit") {
+      changeFromNetwork(NETWORKS[0])
+      changeToNetwork(NETWORKS[1])
+    } else {
+      changeFromNetwork(NETWORKS[1])
+      changeToNetwork(NETWORKS[0])
+    }
+  }, [txType])
+
   return (
     <AppProvider>
       <PriceFeeProvider>


### PR DESCRIPTION
### Steps to Reproduce： 
1. refresh page and ensure the wallet current network is **Ethereum Sepolia**
2. check **Deposit to Scroll** panel, and the fromNetwork and toNetwork is correct.
3. click **Transaction History** and then click the `Claim` button.
4. the tab panel switches to **Withdraw to Ethereum** and **Step 2: Claim on Ethereum**.
5. click **Step 1: Withdraw from Scroll** and will see the wrong fromNetwork and toNetwork.
<img width="668" alt="image" src="https://github.com/scroll-tech/frontends/assets/21138718/0fade7b0-4232-4ecd-9101-2f27adac699d">

### Update:
bind txType and fromNetwork&&toNetwork
