### PR TITLE
Update zkEVM.md

### DIFF
--- a/src/assets/blog/zkEVM.md
+++ b/src/assets/blog/zkEVM.md
@@ -105,7 +105,7 @@ So, it’s clear that the proof of zkEVM needs to contain the following aspects 
 - The bytecode is correctly loaded from persistent storage
   (You are running the correct opcode loaded from a given address)
 - The opcodes in the bytecode are executed one by one consistently
-  (They bytecode is executed in order without missing or skipping any opcode)
+  (The bytecode is executed in order without missing or skipping any opcode)
 - Each opcode is executed correctly
   (Three sub-steps in each opcode are carried out correctly, R/W + computation)
 


### PR DESCRIPTION
Minor typo. Changed "They bytecode is executed in order without missing or skipping any opcode" in L108 with "The bytecode is executed in order without missing or skipping any opcode".

Typo : https://github.com/scroll-tech/frontends/blob/staging/src/assets/blog/zkEVM.md?plain=1#L108