### PR TITLE
fix: balance < gas fee

### DIFF
--- a/src/pages/new-bridge/Send/SendTransaction/BalanceInput.tsx
+++ b/src/pages/new-bridge/Send/SendTransaction/BalanceInput.tsx
@@ -99,6 +99,10 @@ const BalanceInput = props => {
     [selectedToken, balance, disabled],
   )
 
+  const shouldPayFee = useMemo(() => (selectedToken.native ? fee : BigInt(0)), [selectedToken, fee])
+
+  const invalid = useMemo(() => balance <= shouldPayFee, [balance, shouldPayFee])
+
   const handleChangeAmount = e => {
     const amount = sanitizeNumericalString(e.target.value)
     onChange(amount)
@@ -139,7 +143,7 @@ const BalanceInput = props => {
             Available: {displayedBalance}
           </Typography>
         )}
-        <Button className={classes.maxButton} variant="contained" color="info" disabled={disabled} onClick={handleMaxAmount}>
+        <Button className={classes.maxButton} variant="contained" color="info" disabled={disabled || invalid} onClick={handleMaxAmount}>
           (Max)
         </Button>
       </Stack>

--- a/src/pages/new-bridge/hooks/useSufficientBalance.ts
+++ b/src/pages/new-bridge/hooks/useSufficientBalance.ts
@@ -49,12 +49,16 @@ function useSufficientBalance(selectedToken: any, amount?: bigint, fee?: bigint,
       if (!tokenBalance) {
         message = `Insufficient balance. Your account has 0 ${selectedToken.symbol}.`
       } else if (!enoughFeeBalance) {
-        const diff = tokenBalance - totalFee
-        message = `Insufficient balance to cover the cost of tx. The amount should be less than ${toTokenDisplay(
-          diff,
-          selectedToken.decimals,
-          selectedToken.symbol,
-        )}`
+        if (tokenBalance > totalFee) {
+          const diff = tokenBalance - totalFee
+          message = `Insufficient balance to cover the cost of tx. The amount should be less than ${toTokenDisplay(
+            diff,
+            selectedToken.decimals,
+            selectedToken.symbol,
+          )}`
+        } else {
+          message = `Insufficient balance to cover the cost of tx. Please add ETH to pay for tx fees.`
+        }
 
         if (!selectedToken.native) {
           message = `${nativeTokenBalance ? "Insufficient" : "No"} balance to cover the tx fee. Please add ETH to pay for tx fees.`


### PR DESCRIPTION
need to handle the scenario when the balance is less than the gas fee on Deposit panel.

> will consult with the designer to see if there's a better UI/UX solution for these scenarios.

1. show "Insufficient balance to cover the cost of tx. Please add ETH to pay for tx fees." rather than "Insufficient balance to cover the cost of tx. The amount should be less than -0.00436ETH"
2. disable `Max` button when balance <=  gas fee

- [ ] In addition, I think we should display the gas fee in such situations.

![image](https://github.com/scroll-tech/frontends/assets/21138718/3d170913-d97c-4c04-a687-37a61c982a4a)

