### PR TITLE
Set default gasfee for notIsNetworkConnected

### DIFF
--- a/src/pages/new-bridge/hooks/useEstimateSendTransaction.ts
+++ b/src/pages/new-bridge/hooks/useEstimateSendTransaction.ts
@@ -49,7 +49,7 @@ export function useEstimateSendTransaction(props) {
 
   const estimateSend = async () => {
     const isNetworkConnected = await checkConnectedChainId(fromNetwork.chainId)
-    if (!isNetworkConnected) return
+    if (!isNetworkConnected) return BigInt(0)
     const nativeTokenBalance = await networksAndSigners[fromNetwork.chainId].provider.getBalance(walletCurrentAddress)
     if (!nativeTokenBalance) {
       return BigInt(0)


### PR DESCRIPTION
## PR Summary

Set default gasfee for notIsNetworkConnected
When there is no return value in the wrong network, it will cause a calculation error.

<img width="1247" alt="image" src="https://github.com/scroll-tech/frontends/assets/12936800/a052413b-d835-40c4-9fc7-44e4a27137cf">

