### PR TITLE
Adjust displayed gasfee

### DIFF
--- a/src/pages/new-bridge/Send/SendTransaction/index.tsx
+++ b/src/pages/new-bridge/Send/SendTransaction/index.tsx
@@ -60,9 +60,16 @@ const SendTransaction = props => {
 
   const invalidAmountMessage = useCheckValidAmount(amount)
   // fee start
-  const { gasFee: estimatedGasCost, error: estimatedGasCostError, calculateGasFee } = useGasFee(selectedToken)
+  const {
+    gasFee: estimatedGasCost,
+    error: estimatedGasCostError,
+    calculateGasFee,
+    displayedGasFee: displayedEstimatedGasCost,
+  } = useGasFee(selectedToken)
 
   const totalFee = useMemo(() => estimatedGasCost + gasLimit * gasPrice, [estimatedGasCost, gasLimit, gasPrice])
+  const displayedTotalFee = useMemo(() => displayedEstimatedGasCost + gasLimit * gasPrice, [displayedEstimatedGasCost, gasLimit, gasPrice])
+
   const relayFee = useMemo(() => gasLimit * gasPrice, [gasLimit, gasPrice])
 
   const { insufficientWarning } = useSufficientBalance(
@@ -228,9 +235,9 @@ const SendTransaction = props => {
         selectedToken={selectedToken}
         amount={amount}
         priceFeeErrorMessage={priceFeeErrorMessage}
-        totalFee={totalFee}
+        totalFee={displayedTotalFee}
         relayFee={relayFee}
-        estimatedGasCost={estimatedGasCost}
+        estimatedGasCost={displayedEstimatedGasCost}
         bridgeWarning={bridgeWarning}
       />
       <Typography

--- a/src/pages/new-bridge/hooks/useGasFee.ts
+++ b/src/pages/new-bridge/hooks/useGasFee.ts
@@ -17,6 +17,7 @@ const useGasFee = selectedToken => {
   })
 
   const [gasFee, setGasFee] = useState(BigInt(0))
+  const [displayedGasFee, setDisplayedGasFee] = useState(BigInt(0))
   const [gasLimit, setGasLimit] = useState(BigInt(0))
   const [maxFeePerGas, setMaxFeePerGas] = useState<bigint | null>(null)
   const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState<bigint | null>(null)
@@ -36,9 +37,19 @@ const useGasFee = selectedToken => {
       gasPrice = legacyGasPrice as bigint
       priorityFee = null
     }
-    const limit = ((await estimateSend()) * BigInt(120)) / BigInt(100)
+
+    const gas = await estimateSend()
+    const limit = (gas * BigInt(120)) / BigInt(100)
+    const displayedGasPrice = await getPublicClient({ chainId: fromNetwork.chainId }).getGasPrice()
     const estimatedGasCost = BigInt(limit) * BigInt(gasPrice || 1e9)
-    return { gasLimit: limit, gasFee: estimatedGasCost, gasPrice, maxPriorityFeePerGas: priorityFee }
+    const displayedEstimatedGasCost = BigInt(gas) * BigInt(displayedGasPrice || 1e9)
+    return {
+      gasLimit: limit,
+      gasFee: estimatedGasCost,
+      gasPrice,
+      maxPriorityFeePerGas: priorityFee,
+      displayedGasFee: displayedEstimatedGasCost,
+    }
   }
 
   useBlockNumber({
@@ -47,6 +58,7 @@ const useGasFee = selectedToken => {
       calculateGasFee()
         .then(value => {
           setGasFee(value.gasFee)
+          setDisplayedGasFee(value.displayedGasFee)
           setGasLimit(value.gasLimit)
           setMaxFeePerGas(value.gasPrice)
           setMaxPriorityFeePerGas(value.maxPriorityFeePerGas)
@@ -54,6 +66,7 @@ const useGasFee = selectedToken => {
         })
         .catch(error => {
           setGasFee(BigInt(0))
+          setDisplayedGasFee(BigInt(0))
           setGasLimit(BigInt(0))
           setMaxFeePerGas(null)
           setMaxPriorityFeePerGas(null)
@@ -61,7 +74,7 @@ const useGasFee = selectedToken => {
         })
     },
   })
-  return { gasLimit, gasFee, error, calculateGasFee, maxFeePerGas, maxPriorityFeePerGas }
+  return { gasLimit, gasFee, error, calculateGasFee, maxFeePerGas, maxPriorityFeePerGas, displayedGasFee }
 }
 
 export default useGasFee


### PR DESCRIPTION
When calculating balance, use maxFeePerGas to ensure sufficient balance. 
However, when displaying the estimated gas fee in the UI, use gasPrice to show a more accurate gas fee.