### PR TITLE
fix: Typo in history

### DIFF
--- a/src/pages/bridge/components/TxTable/index.tsx
+++ b/src/pages/bridge/components/TxTable/index.tsx
@@ -197,7 +197,7 @@ const TxTable = (props: any) => {
         ) : (
           <NoData
             sx={{ height: ["20rem", "30rem"] }}
-            title="No transaction hisotry"
+            title="No transaction history"
             description="When you bridge assets, your transactions will appear here"
           ></NoData>
         )}


### PR DESCRIPTION
## PR Summary

[comment]: Transaction history has typo


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: Small typo
