### PR TITLE
Add relevant links to "Getting started with Scroll" section

### DIFF
--- a/src/pages/landingpage/GetStart/index.tsx
+++ b/src/pages/landingpage/GetStart/index.tsx
@@ -8,6 +8,7 @@ import SecurityIcon from "@/assets/images/homepage/home/start_link.png"
 import EVMEquivalenceIcon from "@/assets/images/homepage/home/start_setting.png"
 import { FadeInUp } from "@/components/Animation"
 import Button from "@/components/Button"
+import Link from "@/components/Link"
 import SuccessionToView, { SuccessionItem } from "@/components/Motion/SuccessionToView"
 import SectionHeader from "@/components/SectionHeader"
 import { NETWORKS } from "@/constants"
@@ -15,21 +16,41 @@ import { isProduction } from "@/utils"
 
 const tokenName = isProduction ? "ETH" : "testnet ETH"
 const l2NetworkName = isProduction ? NETWORKS[1].name : NETWORKS[1].name + " testnet"
-
+const setuplink = <Link href="https://docs.scroll.io/en/user-guide/setup/">setup page.</Link>
+const bridgelink = (
+  <>
+    <Link href="https://scroll.io/bridge">Bridge your ETH</Link>
+  </>
+)
+const rpclink = (
+  <>
+    <Link href="https://docs.scroll.io/en/developers/developer-quickstart/#network-configuration">Change RPC Provider</Link>
+  </>
+)
+const toolslink = (
+  <>
+    <Link href="https://docs.scroll.io/en/developers/developer-quickstart/#configure-your-tooling">Build with your usual dev tools</Link>
+  </>
+)
 const STEPS = [
   {
     icon: ScalabilityIcon,
-    title: "Bridge your ETH",
-    description: `You can bridge your ${tokenName} to ${l2NetworkName} using our native bridge or another ecosystem bridge. For a walkthrough, start with the user guide’s setup page.`,
+    title: bridgelink,
+    description: (
+      <>
+        You can bridge your {tokenName} to {l2NetworkName} using our native bridge or another ecosystem bridge. For a walkthrough, start with the user
+        guide’s {setuplink}
+      </>
+    ),
   },
   {
     icon: SecurityIcon,
-    title: "Change RPC provider",
+    title: rpclink,
     description: `To configure your Ethereum tools to Scroll you’ll just need to point your favorite builder tools to a Scroll RPC Provider.`,
   },
   {
     icon: EVMEquivalenceIcon,
-    title: "Build with your usual dev tools",
+    title: toolslink,
     description: "Start building with your favorite toolkit.",
   },
 ]
@@ -74,6 +95,9 @@ const StepContainer = styled(SuccessionToView)(({ theme }) => ({
   gridTemplateColumns: "repeat(3, 1fr)",
   gap: "2rem",
   marginBottom: "13rem",
+  "& .MuiLink-root": {
+    fontSize: "2rem",
+  },
   "& > div:nth-of-type(1) img": {
     width: "2.3rem",
   },


### PR DESCRIPTION


## PR Summary

[comment]: Summarise the problem and how the pull request solves it

The "Getting started with Scroll" section on the landing page references the documentation, but does not link to it. This PR adds links to the "Getting started with Scroll" section to relevant pages of the scroll documentation. Also a small styling change to keep linked text at the same font size as it was before the links were added.
---

## Checklist

- [No] There are breaking changes
- [No] I've added/changed/removed ENV variable(s)
- [Not Necessary] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: # (Please provide a more detailed description of your pull request here, explaining the changes made and the reasoning behind them)
The "Getting started with Scroll" section now links to relevant pages of the documentation to aid new developers in getting started with the project.

"Bridge your ETH" now links to https://scroll.io/bridge
"setup page." now links to https://docs.scroll.io/en/user-guide/setup/
"Change RPC Provider" now links to https://docs.scroll.io/en/developers/developer-quickstart/#network-configuration
"Build with your usual dev tools" now links to https://docs.scroll.io/en/developers/developer-quickstart/#configure-your-tooling
The font size of the "MuiLink-root" class is now set to 2rem to keep font sizes consistent with how they were prior to the links being added.