### PR TITLE
Updated styling on Privacy Policy page.  index.tsx

### DIFF
--- a/src/pages/privacyPolicy/index.tsx
+++ b/src/pages/privacyPolicy/index.tsx
@@ -291,7 +291,9 @@ const PrivacyPolicy = () => {
           reorganization, dissolution, or other sale or transfer of some or all of Our assets, whether as a going concern or as part of bankruptcy,
           liquidation, or similar proceeding, in which Personal Data held by Us about our Service users is among the assets transferred.
         </li>
-        <li>For compliance purposes: such as to prevent fraud and/or money laundering.</li>
+        <li>
+          <strong>For compliance purposes:</strong> such as to prevent fraud and/or money laundering.
+        </li>
         <li>
           <strong>For other purposes</strong>: we may use Your information for other purposes, such as data analysis, identifying usage trends,
           determining the effectiveness of our promotional campaigns and to evaluate and improve our Service, products, functionality, services,


### PR DESCRIPTION

## PR Summary

[comment]: Summarise the problem and how the pull request solves it

All headings under "Use of Your Personal Data" were in bold except "For Compliance Purposes". Changed format for consistency.


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: # (Please provide a more detailed description of your pull request here, explaining the changes made and the reasoning behind them)

On the Privacy Policy page there was a slight inconsistency with styling. All but one of the headings under "Use of Your Personal Data" were in bold except "For Compliance Purposes". Updated it to the correct format to ensure consistency.
