### PR TITLE
fix: "loading" takes priority over "disabled"

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,4 +1,5 @@
 import { motion, useCycle } from "framer-motion"
+import { useMemo } from "react"
 import { makeStyles } from "tss-react/mui"
 
 import { ButtonBase, CircularProgress, IconButton, SvgIcon, alpha } from "@mui/material"
@@ -111,6 +112,11 @@ const Button = props => {
 
   const [isHover, setIsHover] = useCycle(false, true)
 
+  const innerDisabled = useMemo(() => {
+    if (loading) return false
+    return disabled
+  }, [loading, disabled])
+
   const handleHover = () => {
     setIsHover()
   }
@@ -119,7 +125,7 @@ const Button = props => {
     // TODO: allow sx, allow size=small/medium
     // avoid setting both 'disabled' and 'loading' to true.
     <motion.div
-      className={cx(classes.wrapper, disabled && classes.wrapperDisabled, gloomy && classes.wrapperGloomy)}
+      className={cx(classes.wrapper, innerDisabled && classes.wrapperDisabled, gloomy && classes.wrapperGloomy)}
       onHoverStart={handleHover}
       onHoverEnd={handleHover}
       animate={isHover ? "expanding" : "normal"}
@@ -130,19 +136,19 @@ const Button = props => {
         </IconButton>
       )}
       <motion.div
-        className={cx(classes.mask, loading && classes.maskLoading, disabled && classes.maskDisabled)}
+        className={cx(classes.mask, loading && classes.maskLoading, innerDisabled && classes.maskDisabled)}
         variants={isMobile ? maskMobile : maskDesktop}
       ></motion.div>
       <ButtonBase
         classes={{
           root: cx(
             classes.button,
-            isHover && !gloomy && !disabled && classes.active,
+            isHover && !gloomy && !innerDisabled && classes.active,
             loading && classes.buttonLoading,
-            disabled && classes.buttonDisabled,
+            innerDisabled && classes.buttonDisabled,
           ),
         }}
-        disabled={disabled || gloomy || loading}
+        disabled={innerDisabled || gloomy || loading}
         {...restProps}
       >
         {children} {loading && <CircularProgress sx={{ color: "inherit" }} size={isMobile ? 18 : 24} thickness={4}></CircularProgress>}

--- a/src/pages/bridge/Send/SendTransaction/BalanceInput.tsx
+++ b/src/pages/bridge/Send/SendTransaction/BalanceInput.tsx
@@ -70,6 +70,9 @@ const useStyles = makeStyles()(theme => ({
     pointerEvents: "none",
     color: "#EBC28E",
   },
+  readOnlyMaxButton: {
+    pointerEvents: "none",
+  },
 }))
 
 const BalanceInput = props => {
@@ -162,7 +165,11 @@ const BalanceInput = props => {
           <Typography className={classes.fromBalance}>Available: {displayedBalance}</Typography>
         )}
 
-        <TextButton underline="always" className={cx(classes.maxButton, disabled && classes.disabledMaxButton)} onClick={handleMaxAmount}>
+        <TextButton
+          underline="always"
+          className={cx(classes.maxButton, disabled && classes.disabledMaxButton, readOnly && classes.readOnlyMaxButton)}
+          onClick={handleMaxAmount}
+        >
           Max
         </TextButton>
       </Stack>


### PR DESCRIPTION
Regarding the real-time estimation of gas fees, even when a user has initiated a transaction request, there may still be a reminder on the page indicating insufficient gas fees, particularly when using the 'max' feature. Since we cannot cancel the Metamask popup, I think it's acceptable to maintain the loading status and error notifications. Users can make their own judgment on whether to cancel the current transaction.

So the page would look like below
![CleanShot 2023-12-06 at 10 15 11@2x](https://github.com/scroll-tech/frontends/assets/21138718/d560f584-5b7c-4503-be52-542727f83abc)

What do you think? Do you have any suggestions? @zzq0826 



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206043668188950