### PR TITLE
FailedRelayed tx support retry feature

### DIFF
--- a/src/pages/bridge/components/TxTable/TxStatusButton.tsx
+++ b/src/pages/bridge/components/TxTable/TxStatusButton.tsx
@@ -111,7 +111,7 @@ const TxStatus = props => {
     }
   }
 
-  if ([TX_STATUS.Dropped, TX_STATUS.FailedRelayed, TX_STATUS.SentFailed, TX_STATUS.Skipped].includes(tx.txStatus)) {
+  if ([TX_STATUS.Dropped, TX_STATUS.SentFailed, TX_STATUS.Skipped].includes(tx.txStatus)) {
     return (
       <Tooltip placement="top" title="Please click on the transaction hash to view the error reason.">
         <Chip
@@ -130,7 +130,7 @@ const TxStatus = props => {
     return <Chip className={cx(classes.chip, classes.successChip)} label="Success"></Chip>
   }
 
-  if (tx.txStatus === TX_STATUS.RelayedReverted) {
+  if (tx.txStatus === TX_STATUS.RelayedReverted || tx.txStatus === TX_STATUS.FailedRelayed) {
     return <ActiveButton type="Retry" tx={tx} />
   }
 

--- a/src/pages/bridge/components/TxTable/index.tsx
+++ b/src/pages/bridge/components/TxTable/index.tsx
@@ -289,7 +289,7 @@ const TxRow = props => {
               href={generateExploreLink(NETWORKS[+!tx.isL1].explorer, tx.hash)}
               className="leading-normal flex-1"
             >
-              {truncateHash(tx.hash)}
+              {truncateHash(tx.replayTxHash || tx.hash)}
             </Link>
           </Typography>
         </Stack>

--- a/src/stores/utils.ts
+++ b/src/stores/utils.ts
@@ -50,6 +50,7 @@ export interface Transaction {
   initiatedAt?: string
   txStatus?: number
   msgHash?: string
+  replayTxHash?: string
 }
 
 export const MAX_OFFSET_TIME = 30 * 60 * 1000
@@ -91,6 +92,7 @@ export const formatBackTxList = (backList, estimatedTimeMap) => {
 
     return {
       hash: tx.hash,
+      replayTxHash: tx.replay_tx_hash,
       fromBlockNumber: tx.block_number,
       toHash,
       toBlockNumber: tx.counterpart_chain_tx?.block_number,


### PR DESCRIPTION
1.Transactions with "FailedRelayed" status support retry.
2.For retried transactions, display the updated replayTxHash.