### PR TITLE
feat: omit yarn.lock file when linting the code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ tests/unit/**
 public/**/*.js
 tsconfig.json
 node_modules/**/*
+yarn.lock


### PR DESCRIPTION
## PR Summary

There is no need for **yarn.lock** file to be present inside lint process.

