### PR TITLE
feat: add separate script for just linting the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "convert:webp": "cwebp -q 100 $1 -o $2",
     "eject": "craco eject",
     "generate:sitemap": "cd scripts && node generate_sitemap.js",
-    "lint": "eslint --fix --max-warnings=0 \"**/*.{ts,tsx}\"",
+    "lint": "eslint . --max-warnings=0 \"**/*.{ts,tsx}\"",
+    "lint:fix": "eslint --fix --max-warnings=0 \"**/*.{ts,tsx}\"",
     "prepare": "husky install",
     "start": "BROWSER=none craco start",
     "test": "npx lint-staged"


### PR DESCRIPTION
## PR Summary

I've added a separate lint script dedicated to performing code linting without applying immediate fixes.

---

## Description

Adding a separate script for lint in addition to **lint:fix** is a good idea, especially if developers want to run the linter without automatically fixing all the issues. It provides more flexibility and allows developers to review the errors and warnings before deciding to apply fixes.

