### PR TITLE
fix: navigation submenu proper background

### DIFF
--- a/src/components/Header/desktop_header.tsx
+++ b/src/components/Header/desktop_header.tsx
@@ -232,7 +232,14 @@ const App = ({ currentMenu }) => {
             inheritViewBox
           ></SvgIcon>
           {item.key === checked && (
-            <StyledPopper open={true} placement="bottom-start" anchorEl={anchorEl} transition bgColor={navbarBg} dark={dark}>
+            <StyledPopper
+              open={true}
+              placement="bottom-start"
+              anchorEl={anchorEl}
+              transition
+              bgColor={navbarBg === "transparent" ? "" : navbarBg}
+              dark={dark}
+            >
               {({ TransitionProps }) => (
                 <Fade {...TransitionProps}>
                   <SubMenuList onClick={handleMouseLeave}>{renderSubMenuList(item.children)}</SubMenuList>


### PR DESCRIPTION
## PR Summary

Proper background color for navigation submenus when in transparent background.

---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [x] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

Applied the proper background color for navigation submenus when in transparent background, so the navigation links are readable and accessible.

Mentioned on the following issue: https://github.com/scroll-tech/frontends/issues/960

### Before:
<img width="1019" alt="Screenshot 2024-02-19 at 07 24 53" src="https://github.com/scroll-tech/frontends/assets/847539/f8533cc9-fd11-448e-8e49-887766ea8388">

### After:
<img width="1085" alt="Screenshot 2024-02-19 at 07 25 16" src="https://github.com/scroll-tech/frontends/assets/847539/42d08483-a656-4bad-87ff-e62cfa2f266b">


