### PR TITLE
refactor: add type for useCheckValidAmount input parameter

### DIFF
--- a/src/hooks/useCheckValidAmount.ts
+++ b/src/hooks/useCheckValidAmount.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 
 import { checkAmountOverflow } from "@/utils"
 
-const useCheckValidAmount = amount => {
+const useCheckValidAmount = (amount: string | undefined) => {
   const [isValid, setIsValid] = useState(true)
   const [message, setMessage] = useState("")
   useEffect(() => {


### PR DESCRIPTION
## PR Summary

The useCheckValidAmount input parameter's type is unclear. This PR solves it.


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [x] I checked whether I should update the docs and did so by updating `/docs`

---

## Description
This pull request introduces a type specification for the amount parameter within the useCheckValidAmount function.

Previously, the parameter amount was implicitly any type that could be interpreted as a string or undefined, leading to potential issues with type safety and clarity.

By explicitly defining the type for amount, this PR aims to enhance code readability and ensure type correctness throughout the function's usage. This minor yet crucial change helps in maintaining the robustness and maintainability of the codebase.