### PR TITLE
fixed the loading state of the Transactions history table component

### DIFF
--- a/src/pages/bridge/components/TxTable/index.tsx
+++ b/src/pages/bridge/components/TxTable/index.tsx
@@ -154,7 +154,7 @@ const TxTable = (props: any) => {
   return (
     <>
       <TableContainer component={Paper} className={classes.tableWrapper}>
-        {data.length ? (
+        {data.length && !loading && (
           <>
             <Box className={classes.tableMinHeight}>
               <Table aria-label="Tx Table">
@@ -191,7 +191,8 @@ const TxTable = (props: any) => {
               </div>
             )}
           </>
-        ) : (
+        )} 
+        {!data.length && !loading && (
           <NoData
             sx={{ height: ["20rem", "30rem"] }}
             title="No transaction history"


### PR DESCRIPTION
## PR Summary

Fixed the loading state for the Transactions History Table component on the 'Bridge' page. Currently, the loading state was overlapping with the No data state. It needed segregation.


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

When you go to the 'bridge page' and click on the 'Transaction History' button, in the dialog, the loading state was overlapping with the No data state. It needed segregation. I also cleaned the code a bit to make it more readable.

