### PR TITLE
fix: missing slash and route name fixes for portal routes

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -45,8 +45,8 @@ const sepoliaRoutes = [
     element: <PrivacyPolicy />,
   },
   {
-    name: "Resources",
-    path: "portal",
+    name: "Portal",
+    path: "/portal",
     element: <Portal />,
   },
   {
@@ -146,8 +146,8 @@ const mainnetRoutes = [
     element: <PrivacyPolicy />,
   },
   {
-    name: "Resources",
-    path: "portal",
+    name: "Portal",
+    path: "/portal",
     element: <Portal />,
   },
   {


### PR DESCRIPTION
Minor syntax error. Added forward slashes and changed route names for portal routes.

syntax error 1: https://github.com/scroll-tech/frontends/blob/sepolia/src/routes/index.tsx?plain=1#L49
syntax error 2: https://github.com/scroll-tech/frontends/blob/sepolia/src/routes/index.tsx?plain=1#L150
