### PR TITLE
open in new tab - Career/news

### DIFF
--- a/src/pages/career/News/index.tsx
+++ b/src/pages/career/News/index.tsx
@@ -74,7 +74,7 @@ const News = () => {
   const { classes } = useStyles()
 
   const handleClick = news => {
-    window.location.href = news.link
+    window.open(news.link, "_blank")
   }
 
   return (


### PR DESCRIPTION
## PR Summary

[comment]: Career/news links changes url directly, I updated them to open in new tab like all other links.


---

## Checklist

- [ n] There are breaking changes
- [ n] I've added/changed/removed ENV variable(s)
- [ y] I checked whether I should update the docs and did so by updating `/docs`

---



