### PR TITLE
Load more button

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generate:sitemap": "cd scripts && node generate_sitemap.js",
     "lint": "eslint --fix --max-warnings=0 \"**/*.{ts,tsx}\"",
     "prepare": "husky install",
-    "start": "BROWSER=none craco start",
+    "start": "set BROWSER=none && craco start",
     "test": "npx lint-staged"
   },
   "lint-staged": {

--- a/src/components/LinesEllipsis/index.tsx
+++ b/src/components/LinesEllipsis/index.tsx
@@ -74,8 +74,8 @@ const LinesEllipsis = props => {
     /* eslint-disable no-control-regex */
     const basedOn = props.basedOn || (/^[\x00-\x7F]+$/.test(props.text) ? "words" : "letters")
 
+    // Handle the case where props.text is not a string to avoid error
     if (typeof props.text !== "string") {
-      // Handle the case where props.text is not a string
       return
     }
 

--- a/src/components/LinesEllipsis/index.tsx
+++ b/src/components/LinesEllipsis/index.tsx
@@ -74,6 +74,11 @@ const LinesEllipsis = props => {
     /* eslint-disable no-control-regex */
     const basedOn = props.basedOn || (/^[\x00-\x7F]+$/.test(props.text) ? "words" : "letters")
 
+    if (typeof props.text !== "string") {
+      // Handle the case where props.text is not a string
+      return
+    }
+
     if (basedOn === "words") {
       units.current = props.text.split(/\b|(?=\W)/)
     } else if (basedOn === "letters") {
@@ -151,7 +156,7 @@ const LinesEllipsis = props => {
   return (
     <>
       <Component className={`LinesEllipsis ${clamped ? "LinesEllipsis--clamped" : ""} ${className}`} ref={targetRef} {...rest}>
-        {trimRight ? displayedText.trimRight() : displayedText}
+        {trimRight && displayedText ? displayedText.trimRight() : displayedText}
         {clamped && <span className="LinesEllipsis-ellipsis">{ellipsis}</span>}
       </Component>
       <div style={agentStyle} ref={shadowRef} className={`LinesEllipsis-shadow ${className}`}></div>


### PR DESCRIPTION
## PR Summary

[comment]: Summarise the problem and how the pull request solves it

## Fixes a bug where the "Load more" button under Ecosystem >> Browse all protocols >> All categories >> NFT breaks when clicked consecutively.


---

## Checklist

- [NO ] There are breaking changes
- [ NO] I've added/changed/removed ENV variable(s)
- [Not necessary ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: #This pull request addresses the issue by introducing a guard to prevent the application of the .trimRight() method to the displayedText variable if its value is falsy. The guard ensures that the method is only executed when displayedText is truthy, reducing the potential for errors or issues that might arise when attempting to apply .trimRight() to falsy values. Furthermore, this adjustment enhances the stability of the "Load more" button functionality, particularly when clicked in quick succession is the said area.

This pull request addresses the issues raised in #996  

#Ignore the package.json 

https://github.com/scroll-tech/frontends/assets/64384345/fe053e8b-3b20-4708-bb9a-c8f9c1cb9906





