### PR TITLE
[BUG]Update StoryCard.tsx

### DIFF
--- a/src/pages/ourStory/BuildingStory/StoryCard.tsx
+++ b/src/pages/ourStory/BuildingStory/StoryCard.tsx
@@ -116,7 +116,7 @@ const StoryCard = props => {
       <Card {...restProps} elevation={0} className={classes.card}>
         {cover && (
           <Box className={classes.cardMediaWrapper}>
-            <CardMedia sx={{ height: ["13rem", "23rem"] }} classes={{ root: classes.cardMedia }} image={cover} />
+            <CardMedia sx={{ height: ["16rem", "23rem"] }} classes={{ root: classes.cardMedia }} image={cover} />
             <Typography className={classes.cardMediaTitle}>{imageTitle}</Typography>
             <ScrollLogo light className={classes.cardMediaLogo}></ScrollLogo>
           </Box>


### PR DESCRIPTION
## PR Summary
There is a BUG in the blog of the landing page, causing that in screens smallers than 600px, part of the text and the SVG are overlapped.

I changed the values of the CardMedia, from 13rem of height to 16rem.
