### PR TITLE
Fix: Change the height of cardMedia for screens smaller than 600px / Update StoryCard.tsx 

### DIFF
--- a/src/pages/ourStory/BuildingStory/StoryCard.tsx
+++ b/src/pages/ourStory/BuildingStory/StoryCard.tsx
@@ -116,7 +116,7 @@ const StoryCard = props => {
       <Card {...restProps} elevation={0} className={classes.card}>
         {cover && (
           <Box className={classes.cardMediaWrapper}>
-            <CardMedia sx={{ height: ["13rem", "23rem"] }} classes={{ root: classes.cardMedia }} image={cover} />
+            <CardMedia sx={{ height: ["16rem", "23rem"] }} classes={{ root: classes.cardMedia }} image={cover} />
             <Typography className={classes.cardMediaTitle}>{imageTitle}</Typography>
             <ScrollLogo light className={classes.cardMediaLogo}></ScrollLogo>
           </Box>


### PR DESCRIPTION
## PR Summary

In the blog of the landing page, there is a bug that causes an overlapping between a text and an SVG in screens smaller than 600px. The bug was caused because of the variable cardMedia whose height for screens smaller than 600px was 13rem. Now the height was changed to 16rem.


---

## Checklist

- [NO] There are breaking changes
- [NO] I've added/changed/removed ENV variable(s)
- [NOT NECESSARY] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

This change makes the website better because it improves the UX, and fixes an issue it has.

<img width="414" alt="Scroll-page-" src="https://github.com/scroll-tech/frontends/assets/161076076/75486d50-6761-4d43-a6ec-7bf39710ec1f">
<img width="414" alt="Scroll-page" src="https://github.com/scroll-tech/frontends/assets/161076076/f5862566-9d4e-4164-ae53-e3ffa179f1aa">

Note that in the first image it is the overlapping, and in the other one there is no overlapping, due to the height change (From 13rem to 16rem).

Also note that this also change the other card that says "Build with Scroll", but does not affect anything on it more than the height.


