### PR TITLE
feat: [1016] add default placeholder image for better fallback

### DIFF
--- a/src/pages/ecosystem/Protocols/ProtocolList/ProtocolCard.tsx
+++ b/src/pages/ecosystem/Protocols/ProtocolList/ProtocolCard.tsx
@@ -144,6 +144,7 @@ const ProtocolCard = props => {
     }
     onResize()
   }
+
   return (
     <Box className={cx(classes.grid, className)} ref={cardRef} {...restProps}>
       <Stack
@@ -155,7 +156,13 @@ const ProtocolCard = props => {
           gridArea: "logo",
         }}
       >
-        <Img alt={name} src={`${ecosystemListLogoUrl}${name}${ext}`} placeholder={hash} width={isMobile ? 48 : 88} height={isMobile ? 48 : 88}></Img>
+        <Img
+          alt={name}
+          src={`${ecosystemListLogoUrl}${name}${ext}`}
+          placeholder={hash ?? "/logo.svg"}
+          width={isMobile ? 48 : 88}
+          height={isMobile ? 48 : 88}
+        ></Img>
       </Stack>
       <Stack direction="row" alignItems="center" gap="0.8rem" className={classes.name}>
         <Typography sx={{ fontSize: ["2rem", "2.4rem"], lineHeight: ["2.8rem", "3.2rem"], fontWeight: 600 }}>{name}</Typography>


### PR DESCRIPTION
## PR Summary

This PR addresses the absence of a default placeholder image in the `Img` component used throughout the application. Previously, if the `hash` prop was not provided, the `Img` component would render without a placeholder, leading to a less desirable user experience with missing visual cues. This change ensures that a default placeholder image is used whenever the `hash` prop is missing, enhancing the application's visual consistency and user experience.

---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

In the current implementation of the `Img` component from the `react-cool-img` package, there's no fallback for a missing `hash` prop, which results in an empty image space. This can degrade the user's experience, especially in a visually driven application. To improve this, I have introduced a conditional rendering for the `placeholder` prop of the `Img` component. Now, if the `hash` is not provided, the component will use a default `/logo.svg` as a placeholder. This enhancement makes the image loading process smoother and ensures that the UI remains engaging and informative, even when specific image data is unavailable.

This change does not introduce any breaking changes, nor does it add, change, or remove any environment variables. I have reviewed the documentation and determined that no updates are necessary for this enhancement.

Referenced issue: [scroll-tech/frontends#1016](https://github.com/scroll-tech/frontends/issues/1016)
