### PR TITLE
chnage error text color

### DIFF
--- a/src/components/Footer/Subscribe/index.tsx
+++ b/src/components/Footer/Subscribe/index.tsx
@@ -76,7 +76,7 @@ const Subscribe = () => {
                 ></EmailInput>
 
                 {customMessage && (
-                  <Typography sx={{ position: "absolute", fontSize: "1.6rem", textAlign: "center", mt: "1rem", width: "100%" }}>
+                  <Typography sx={{ position: "absolute", fontSize: "1.6rem", textAlign: "center", mt: "1rem", width: "100%",color: "red" }}>
                     {customMessage}
                   </Typography>
                 )}


### PR DESCRIPTION
## PR Summary

[comment]: Summarise the problem and how the pull request solves it
change the error color from normal to red to aid user experience

---

## Checklist
one change alone in the subscribe components
-

---

## Description
I simply made the color of the error message in the news letter subscription to red, errors are meant to give warnings and just leaving the text as normal may fail to catch some users attention
