### PR TITLE
Fix search results on ecosystem page

### DIFF
--- a/src/pages/ecosystem/Protocols/ProtocolList/ProtocolCard.tsx
+++ b/src/pages/ecosystem/Protocols/ProtocolList/ProtocolCard.tsx
@@ -185,7 +185,7 @@ const ProtocolCard = props => {
       </Stack>
       <LinesEllipsis
         className={classes.desc}
-        text={desc}
+        text={desc || ""}
         maxLine={isExpended ? 100 : isMobile ? 4 : 2}
         ellipsis={
           <>


### PR DESCRIPTION
## PR Summary

Searching for “**okx**” in the search input on the ecosystem page causes the site to crash. The root cause of this is that there is no `desc` in the fetched “**OKX NFT Marketplace**” data. To fix this error, when we add a condition for the `desc` data by changing `text={desc}` on line 188 in the `ProtocolCard.tsx` file, this error disappears.

---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

When we type the word “**okx**” in the search input on the ecosystem page and "**OKX NFT Marketplace**" is encountered on page 26 of the data on the ecosystem page, an error occurs that causes the site to crash. This error is the absence of the `desc` field in the “**OKX NFT Marketplace**” data retrieved. To fix this error, we need to check for the presence of `desc` data by adding a condition to `text={desc}` on line 188 in the `ProtocolCard.tsx` file.

One of the main causes of this error is the absence of `desc` data. In this case, the existing code generates an error by trying to process data that doesn't exist, causing the site to crash.

We check for the presence of `desc` data by updating this part of the code to `text={desc || ""}`. If the `desc` data is not present, we can avoid the error by skipping this part of the code. This makes the application more robust and fault tolerant.

