### PR TITLE
ci: disable auto version bump, auto merge back

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -6,7 +6,7 @@ name: "Bump Version on sepolia"
 on:
   push:
     branches:
-      - sepolia
+      - disabled-sepolia
 
 jobs:
   bump-version:

--- a/.github/workflows/merge_prod_back_to_dev.yml
+++ b/.github/workflows/merge_prod_back_to_dev.yml
@@ -5,7 +5,7 @@ name: "Merge Prod Back to Dev"
 on:
   push:
     branches:
-      - mainnet
+      - disabled-mainnet
 
 jobs:
   merge-back:


### PR DESCRIPTION
-------

## PR Summary

disable auto version bump and auto merge back github actions

action will stop once this change is in mainnet and sepolia

https://www.notion.so/scrollzkp/remove-auto-aprove-merge-squash-in-frontend-repo-c089a2f22f2a4e4bbf8b67d684e29f53