### PR TITLE
[UX] improvement for badges navigation

### DIFF
--- a/src/pages/canvas-badge/Badges/BadgeList/index.tsx
+++ b/src/pages/canvas-badge/Badges/BadgeList/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react"
-import { useNavigate } from "react-router-dom"
 import { usePrevious } from "react-use"
 import "react-virtualized/styles.css"
 
@@ -25,7 +24,6 @@ const BadgeList = props => {
     onAddPage,
     ...restProps
   } = props
-  const navigate = useNavigate()
   const [loading, setLoading] = useState(false)
   const prePage = usePrevious(page)
   const [badgeList, setBadgeList] = useState([])
@@ -82,7 +80,8 @@ const BadgeList = props => {
   }
 
   const handleClickBadge = ({ badgeContract }) => {
-    navigate(`/canvas/badge-contract/${badgeContract}`)
+    // Open the link in a new tab
+    window.open(`/canvas/badge-contract/${badgeContract}`, '_blank')
   }
 
   if (loading && !badgeList.length) {


### PR DESCRIPTION
Me as a user wants to open a badge in a new tab instead of navigating to it. This improves UX A LOT.

## PR Summary

[comment]: Open badge page in a new tab.


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: From UX perspective its inconvenient to open a badge page in a same tab, it should be new tab.
Ideally it's to have an ability to right click on badge to open in a new tab.
