### PR TITLE
# fix: fetch token price only at /bridge.*

### DIFF
--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -1,13 +1,13 @@
-import { useState } from "react"
 import useSWR from "swr"
 
 import { CHAIN_ID } from "@/constants"
 
-const useTokenPrice = tokenList => {
-  const [prices, setPrices] = useState({})
+let PRICES = {}
 
+const useTokenPrice = tokenList => {
   const fetchPrice = async () => {
     try {
+      if (typeof window === "object" && !window.location.pathname.startsWith("/bridge")) return { ...PRICES }
       const tokens = tokenList.filter(token => token.chainId === CHAIN_ID.L1 && token.address).map(token => token.address)
       const tokenAddresses = tokens.join("%2C")
 
@@ -29,9 +29,8 @@ const useTokenPrice = tokenList => {
         erc20Price = await results[1].value.json()
       }
 
-      const newPrices = { ...prices, ...ethPrice, ...erc20Price }
-      setPrices(newPrices)
-      return newPrices
+      PRICES = { ...PRICES, ...ethPrice, ...erc20Price }
+      return { ...PRICES }
     } catch (error) {
       throw error
     }
@@ -41,7 +40,7 @@ const useTokenPrice = tokenList => {
 
   return {
     loading: isValidating,
-    price: data || prices,
+    price: data || {},
     error,
   }
 }


### PR DESCRIPTION
-------

## PR Summary

[comment]: Summarise the problem and how the pull request solves it
GEN-991
https://www.notion.so/scrollzkp/Only-call-token-price-API-when-needed-8f8cd6dcd15e48e9b59962d0cc74c47c?pvs=4
only fetch token price at /bridge.*

---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: # (Please provide a more detailed description of your pull request here, explaining the changes made and the reasoning behind them)