### PR TITLE
feat: support start/end date for community events

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -80,13 +80,6 @@ to = "https://badge-registry.canvas.scroll.cat/_next/:splat"
 status = 200
 
 [[redirects]]
-from = "/events"
-to = "https://community.scroll.cat/events"
-status = 200
-query = { page_number = ":page_number", page_size = ":page_size" }
-force = true
-
-[[redirects]]
 from = "/airdrop-faq"
 to = "https://scroll-faqs.gitbook.io/faqs"
 status = 301

--- a/src/apis/community.ts
+++ b/src/apis/community.ts
@@ -1,2 +1,2 @@
 export const communityOrigin = "https://community.scroll.cat"
-export const communityEventListUrl = "/events"
+export const communityEventListUrl = `${communityOrigin}/events`

--- a/src/constants/community.ts
+++ b/src/constants/community.ts
@@ -37,6 +37,7 @@ export const COMMUNITY_REGION_LIST = [
   "Europe",
   "Middle East",
   "North America",
+  "Online",
   "Pacific",
   "South America",
 ]

--- a/src/pages/community/Events/EventCard.tsx
+++ b/src/pages/community/Events/EventCard.tsx
@@ -37,8 +37,29 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
+const DateTag = props => {
+  const { startDate, endDate } = props
+  return (
+    <Typography
+      sx={{
+        fontSize: ["1.4rem", "1.6rem"],
+        fontWeight: 600,
+        lineHeight: ["2"],
+        cursor: "inherit",
+        borderRadius: "1.5rem",
+        background: "#FFEEDA",
+        padding: "0rem 1.2rem",
+      }}
+    >
+      <SvgIcon sx={{ fontSize: ["1.6rem"], marginRight: ["0.6rem"] }} component={TimeIcon} inheritViewBox></SvgIcon>
+      {!endDate && dayjs(startDate).format("MMMM D, YYYY")}
+      {endDate && `${dayjs(startDate).format("MMM D")} - ${dayjs(endDate).format("MMM D, YYYY")}`}
+    </Typography>
+  )
+}
+
 const EventCard = props => {
-  const { image, city, country, url, date, ...restProps } = props
+  const { image, city, country, url, ...restProps } = props
 
   const { classes } = useStyles()
 
@@ -47,20 +68,7 @@ const EventCard = props => {
       <Card {...restProps} elevation={0} classes={{ root: classes.card }}>
         <img alt="Event cover" src={communityOrigin + image} className={classes.cover} />
         <Stack direction="row" gap="1rem">
-          <Typography
-            sx={{
-              fontSize: ["1.4rem", "1.6rem"],
-              fontWeight: 600,
-              lineHeight: ["2"],
-              cursor: "inherit",
-              borderRadius: "1.5rem",
-              background: "#FFEEDA",
-              padding: "0rem 1.2rem",
-            }}
-          >
-            <SvgIcon sx={{ fontSize: ["1.6rem"], marginRight: ["0.6rem"] }} component={TimeIcon} inheritViewBox></SvgIcon>
-            {dayjs(date).format("MMMM D, YYYY")}
-          </Typography>
+          <DateTag {...props} />
           <Typography
             sx={{
               fontSize: ["1.4rem", "1.6rem"],


### PR DESCRIPTION
## PR Summary

1. add `Online` as region filter
1. replace `scroll.io/events` with `community.scroll.cat/events` for caching and local development
1. update UI to support start/end date


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [x] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: # (Please provide a more detailed description of your pull request here, explaining the changes made and the reasoning behind them)