### PR TITLE
fix: incorrect background color reference in `sx` prop

### DIFF
--- a/src/app/_components/Portal/index.tsx
+++ b/src/app/_components/Portal/index.tsx
@@ -34,7 +34,7 @@ const BUILDER_LIST = [
 
 const Portal = () => {
   return (
-    <Box sx={{ backgroundColor: "themeBackground.light" }}>
+    <Box sx={{ backgroundColor: theme => theme.palette.background.light }}>
       <Container sx={{ py: ["5.6rem", "10.6rem"] }}>
         {BUILDER_LIST.map(({ title, items }) => (
           <Fragment key={title}>


### PR DESCRIPTION
Fixed background color in the `sx` prop by replacing `"themeBackground.light"` with the correct approach:  

```jsx
<Box sx={{ backgroundColor: theme => theme.palette.background.light }}>
```

This ensures proper theme handling in MUI.

