### PR TITLE
feat: change hero CTA from "Bridge to Scroll" to "Swap on Scroll" (#1…

### DIFF
--- a/src/app/_components/Hero/index.tsx
+++ b/src/app/_components/Hero/index.tsx
@@ -5,7 +5,7 @@ import { Box, Container, Stack, Typography } from "@mui/material"
 import HeroMobileSvg from "@/assets/svgs/landingpage/hero-bg-mobile.svg?url"
 import HeroSvg from "@/assets/svgs/landingpage/hero-bg.svg?url"
 import Button from "@/components/Button"
-import { BRIDGE_URL, DOC_URL } from "@/constants/link"
+import { DOC_URL, SWAP_URL } from "@/constants/link"
 
 const ANNOUNCEMENT_HEIGHT = "0rem"
 
@@ -44,13 +44,8 @@ const LandingHero = () => {
             Build now
           </Button>
 
-          <Button
-            href={BRIDGE_URL}
-            target="_blank"
-            className="!w-[180px] sm:!w-[250px]"
-            gaEvent={{ event: "click_landing", label: "Bridge to Scroll" }}
-          >
-            Bridge to Scroll
+          <Button href={SWAP_URL} target="_blank" className="!w-[180px] sm:!w-[250px]" gaEvent={{ event: "click_landing", label: "Swap on Scroll" }}>
+            Swap on Scroll
           </Button>
         </Stack>
       </Container>

--- a/src/constants/link.ts
+++ b/src/constants/link.ts
@@ -5,6 +5,7 @@ export const LEVEL_UP_URL = "https://www.levelup.xyz/"
 const USER_PORTAL_BASE_URL = process.env.NEXT_PUBLIC_USER_PORTAL_BASE_URL
 
 export const BRIDGE_URL = `${USER_PORTAL_BASE_URL}/bridge`
+export const SWAP_URL = "https://swap.scroll.io"
 export const ECOSYSTEM_URL = "/ecosystem"
 export const SESSIONS_URL = `${USER_PORTAL_BASE_URL}/sessions`
 


### PR DESCRIPTION
…581)

Update the landing page hero button to link to swap.scroll.io instead of the bridge, to experiment with inbound traffic from scroll.io.

## PR Summary

[comment]: Summarise the problem and how the pull request solves it


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [ ] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: # (Please provide a more detailed description of your pull request here, explaining the changes made and the reasoning behind them)

