### PR TITLE
stop fetching blog index on every next config load

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,6 @@ import {withSentryConfig} from "@sentry/nextjs";
 
 // eslint-disable-next-line prettier/prettier
 import packageJson from "./package.json" with { type: "json" };
-import "./scripts/download-blog-posts.data.json.mjs"
 import createMDX from "@next/mdx"
 import rehypeRaw from "rehype-raw"
 import rehypeKatex from "rehype-katex"


### PR DESCRIPTION
## what changed
removed the side-effect import of \scripts/download-blog-posts.data.json.mjs\ from \
ext.config.mjs\.

## why
that script runs \etchPosts()\ at module load (top-level \wait\), so it ran whenever Next loaded the config — including \
ext dev\ and \
ext build\. that meant every build depended on reaching \log.scroll.cat\, added latency, and could fail in offline or locked-down CI even though the blog list is already checked in under \src/assets/blog/\.

updating the list is already a separate step via \yarn fetch:bloglist\ / \
pm run fetch:bloglist\ in package.json, so the config import was redundant for normal builds.

## testing
not run here (local node_modules install had issues); change is a one-line removal of an import.
