### PR TITLE
feat: revert Scroll App changes and rename Scroll Open to Open Economy

### DIFF
--- a/src/app/_components/Hero/index.tsx
+++ b/src/app/_components/Hero/index.tsx
@@ -5,7 +5,7 @@ import { Box, Container, Stack, Typography } from "@mui/material"
 import HeroMobileSvg from "@/assets/svgs/landingpage/hero-bg-mobile.svg?url"
 import HeroSvg from "@/assets/svgs/landingpage/hero-bg.svg?url"
 import Button from "@/components/Button"
-import { DOC_URL, SWAP_URL } from "@/constants/link"
+import { BRIDGE_URL, DOC_URL } from "@/constants/link"
 
 const ANNOUNCEMENT_HEIGHT = "0rem"
 
@@ -44,8 +44,13 @@ const LandingHero = () => {
             Build now
           </Button>
 
-          <Button href={SWAP_URL} target="_blank" className="!w-[180px] sm:!w-[250px]" gaEvent={{ event: "click_landing", label: "Swap on Scroll" }}>
-            Swap on Scroll
+          <Button
+            href={BRIDGE_URL}
+            target="_blank"
+            className="!w-[180px] sm:!w-[250px]"
+            gaEvent={{ event: "click_landing", label: "Bridge to Scroll" }}
+          >
+            Bridge to Scroll
           </Button>
         </Stack>
       </Container>

--- a/src/app/_components/Portal/index.tsx
+++ b/src/app/_components/Portal/index.tsx
@@ -22,7 +22,7 @@ const Portal = () => {
       items: [
         { icon: Doc, label: "Developer Docs", content: "Everything you need to start building", href: DOC_URL },
         { icon: Levelup, label: "Level Up", content: "Learn ZK and test your dev skills", href: LEVEL_UP_URL },
-        { icon: ScrollOpen, label: "Scroll open", content: "A six-week builder program with a $100,000 prize pool", href: SCROLL_OPEN_URL },
+        { icon: ScrollOpen, label: "Open Economy", content: "Take the money test to see where your finances are", href: SCROLL_OPEN_URL },
       ],
     },
     {

--- a/src/components/Header/announcement.tsx
+++ b/src/components/Header/announcement.tsx
@@ -15,7 +15,7 @@ const Announcement = () => {
     if (!isSepolia && isHome) {
       return (
         <>
-          Join Scroll Open: Build the Future of the Open Economy{" "}
+          Join Open Economy: Build the Future of the Open Economy{" "}
           <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
           Jan 27 - March 17
           <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
@@ -27,7 +27,7 @@ const Announcement = () => {
 
   const rightHref = useMemo(() => {
     if (!isSepolia && isHome) {
-      return "https://open.scroll.io"
+      return "https://openeconomyos.com/"
     }
     return ""
   }, [isSepolia, isHome])

--- a/src/components/Header/data.ts
+++ b/src/components/Header/data.ts
@@ -34,7 +34,7 @@ const sepoliaNavigations: Navigation[] = [
       },
       {
         rootKey: "build",
-        label: "Scroll Open",
+        label: "Open Economy",
         key: "scroll-open",
         href: SCROLL_OPEN_URL,
       },
@@ -79,7 +79,7 @@ const mainnetNavigations: Navigation[] = [
       },
       {
         rootKey: "build",
-        label: "Scroll Open",
+        label: "Open Economy",
         key: "scroll-open",
         href: SCROLL_OPEN_URL,
       },

--- a/src/constants/link.ts
+++ b/src/constants/link.ts
@@ -1,11 +1,10 @@
 export const DOC_URL = "https://docs.scroll.io/en/home/"
-export const SCROLL_OPEN_URL = "https://open.scroll.io"
+export const SCROLL_OPEN_URL = "https://openeconomyos.com/"
 export const LEVEL_UP_URL = "https://www.levelup.xyz/"
 
 const USER_PORTAL_BASE_URL = process.env.NEXT_PUBLIC_USER_PORTAL_BASE_URL
 
 export const BRIDGE_URL = `${USER_PORTAL_BASE_URL}/bridge`
-export const SWAP_URL = "https://swap.scroll.io"
 export const ECOSYSTEM_URL = "/ecosystem"
 export const SESSIONS_URL = `${USER_PORTAL_BASE_URL}/sessions`
 


### PR DESCRIPTION
## Summary
- Revert hero CTA from "Swap on Scroll" back to "Bridge to Scroll" (reverts #1581)
- Rename "Scroll Open" copy to "Open Economy" across the site (portal card, header nav, announcement)
- Update `SCROLL_OPEN_URL` to `https://openeconomyos.com/`
- Update "Open Economy" builders card description to "Take the money test to see where your finances are"
