### PR TITLE
feat: change hero headline from "One Sub" to "One Plan"

### DIFF
--- a/src/app/_components/Hero/index.tsx
+++ b/src/app/_components/Hero/index.tsx
@@ -29,8 +29,8 @@ const LandingHero = () => {
       />
       <Container>
         <Typography sx={{ typography: "title", fontSize: ["28px", "48px"], lineHeight: ["44px", "80px"], mb: ["24px", "40px"] }}>
-          {/* mobile breaks after every clause, desktop keeps "One Sub, Every Model," on one line */}
-          {"One Sub, "}
+          {/* mobile breaks after every clause, desktop keeps "One Plan, Every Model," on one line */}
+          {"One Plan, "}
           <Box component="br" sx={{ display: ["inline", "none"] }} />
           Every Model,
           <br />


### PR DESCRIPTION
Follow-up to #1594 — copy tweak only.

| Before | After |
|---|---|
| **One Sub**, Every Model, Secured by ZK | **One Plan**, Every Model, Secured by ZK |

No layout change: the responsive line break and button are untouched. "One Plan" is one character longer than "One Sub", which does not affect the mobile break (it already breaks after this clause) or the desktop line, which has ample room at 48px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)