### PR TITLE
fix: network type was silently any instead of strict

### DIFF
--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -1,4 +1,4 @@
-type EmptyNetwork = ValidNetwork<string, never>
+type EmptyNetwork = Partial<ValidNetwork>
 
 type ValidNetwork = {
   name: string


### PR DESCRIPTION
closes #964

## what

`Network` (the type used across the app for network objects) was silently `any`, so every consumer lost type-safety on its fields - typos and wrong shapes compiled clean.

## why

`EmptyNetwork` was declared as `ValidNetwork<string, never>`, but `ValidNetwork` is not generic. Because `src/types/network.d.ts` is covered by `skipLibCheck`, TypeScript never flagged the invalid instantiation and silently resolved `EmptyNetwork` to `any`. That collapsed the intersection `Network = EmptyNetwork & ValidNetwork` to `any`.

## how

Declare `EmptyNetwork` as `Partial<ValidNetwork>` so the intersection resolves to a strict `ValidNetwork` and `Network` is a real type again. `EmptyNetwork` is only ever used inside the `Network` intersection, so the blast radius is limited to that.

## verification

Ran the repo typechecker (`tsc --noEmit`) before/after:

- before: `const n: Network = 123` compiles (Network is `any`)
- after: `const n: Network = 123` errors `TS2322` (`number` not assignable to `ValidNetwork`) - Network is strict again
- zero new errors across the whole repo. The pre-existing `TS2307: Cannot find module '@/assets/...'` errors are unrelated - they come from running bare `tsc` without Next's webpack asset resolution, and are present identically before and after this change.
