### PR TITLE
feat(landing): heavier product titles in the rail and panel heads

### DIFF
--- a/scripts/build-landing.mjs
+++ b/scripts/build-landing.mjs
@@ -58,6 +58,24 @@ once(
   "body {\n    margin: 0; min-height: 100vh; box-sizing: border-box; display: grid; place-items: center; padding: 24px;\n    background: transparent;   /* the component paints no background of its own */\n    font-family: ui-sans-serif, -apple-system, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif;\n  }",
 )
 
+// ---- the product titles in the rail and the panel heads: Zhengqi 2026-09-12 asked for
+// "Compass API" and "AI Hardware" in bold — next to the active, ink-coloured "Compass" the
+// two faint serif names read thin. Instrument Serif has no bold cut, and the browser's
+// synthetic bold smears it, so this thickens the letters the way his own file does for
+// .display and .section-title: a hairline stroke in the text colour. 0.7px at 22–24px is
+// the semibold weight (0.5 barely showed, 0.9 went clumsy); all three names get it so the
+// rail stays one voice, the panel heads on phones likewise. ----
+once(
+  "rail names heavier",
+  ".rail__name{\n  font-family:var(--serif);font-size:1.375rem;font-weight:400;",
+  ".rail__name{\n  font-family:var(--serif);font-size:1.375rem;font-weight:400;-webkit-text-stroke:.7px currentColor;",
+)
+once(
+  "panel names heavier",
+  ".panel__name{font-family:var(--serif);font-size:1.5rem;font-weight:400}",
+  ".panel__name{font-family:var(--serif);font-size:1.5rem;font-weight:400;-webkit-text-stroke:.7px currentColor}",
+)
+
 // ---- the waitlist form: his submitEmail only pretends; this posts to Loops ------------
 const formId = constant("LOOPS_FORM_ID")
 const listId = constant("LOOPS_MAILING_LIST_ID")


### PR DESCRIPTION
## Summary

Zhengqi asked for "Compass API" and "AI Hardware" in bold — beside the active, ink-coloured "Compass" the two faint serif names in the product rail read thin. Instrument Serif has no bold cut and the browser's synthetic bold smears it, so the build script gives `.rail__name` and `.panel__name` a 0.7px text stroke in the text colour — the technique Glen's own file uses on `.display` and `.section-title`. All three names take it so the rail stays one voice; the panel heads on phones likewise. `design/landing.html` is untouched (the edit lives in `scripts/build-landing.mjs`, as with the other fills).

0.5px barely showed and 0.9px went clumsy; 0.7px reads as semibold.

## Test plan

- [x] `yarn build:landing` regenerates `public/landing.html`; computed `-webkit-text-stroke-width` is 0.7px on both selectors
- [x] Headless Chrome at 1728 (rail) and 390 (panel head): heavier titles, colours unchanged, nothing else moved
- [x] eslint clean on the script

Cherry-picked from `feat/landing-redesign-v2` (de290c78); everything else on that branch is already in sepolia via #1617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
